### PR TITLE
path error readfile in windows

### DIFF
--- a/static/static.go
+++ b/static/static.go
@@ -32,7 +32,7 @@ func Data() (map[string][]string, error) {
 	result := make(map[string][]string, len(files))
 	for _, f := range files {
 		filename := f.Name()
-		currentPath := filepath.Join("data", filename)
+		currentPath := "data/" + filename
 		fileData, err := data.ReadFile(currentPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
 using //go:embed,  the directory separator is forward slash / enven windows.  but pathfile join func use \

![image](https://github.com/user-attachments/assets/1aaf2488-318c-4477-9e5f-c086049e7e21)

Thanks again for your teaching, master.
